### PR TITLE
CVE-2025-6032: machine init: fix tls check

### DIFF
--- a/pkg/machine/ocipull/ociartifact.go
+++ b/pkg/machine/ocipull/ociartifact.go
@@ -224,7 +224,7 @@ func (o *OCIArtifactDisk) getDestArtifact() (types.ImageReference, digest.Digest
 	}
 	fmt.Printf("Looking up Podman Machine image at %s to create VM\n", imgRef.DockerReference())
 	sysCtx := &types.SystemContext{
-		DockerInsecureSkipTLSVerify: types.NewOptionalBool(!o.pullOptions.TLSVerify),
+		DockerInsecureSkipTLSVerify: o.pullOptions.SkipTLSVerify,
 	}
 	imgSrc, err := imgRef.NewImageSource(o.ctx, sysCtx)
 	if err != nil {

--- a/pkg/machine/ocipull/pull.go
+++ b/pkg/machine/ocipull/pull.go
@@ -21,8 +21,8 @@ import (
 // PullOptions includes data to alter certain knobs when pulling a source
 // image.
 type PullOptions struct {
-	// Require HTTPS and verify certificates when accessing the registry.
-	TLSVerify bool
+	// Skip TLS verification when accessing the registry.
+	SkipTLSVerify types.OptionalBool
 	// [username[:password] to use when connecting to the registry.
 	Credentials string
 	// Quiet the progress bars when pushing.
@@ -46,7 +46,7 @@ func Pull(ctx context.Context, imageInput types.ImageReference, localDestPath *d
 	}
 
 	sysCtx := &types.SystemContext{
-		DockerInsecureSkipTLSVerify: types.NewOptionalBool(!options.TLSVerify),
+		DockerInsecureSkipTLSVerify: options.SkipTLSVerify,
 	}
 	if options.Credentials != "" {
 		authConf, err := parse.AuthConfig(options.Credentials)


### PR DESCRIPTION
Ensure we verify the TLS connection when pulling the OCI image.

Bugs: bsc#1245320
Fixes: CVE-2025-6032