### PR TITLE
CVE-2025-6032: machine init: fix tls check

### DIFF
--- a/pkg/machine/ocipull/pull.go
+++ b/pkg/machine/ocipull/pull.go
@@ -18,8 +18,8 @@ import (
 // PullOptions includes data to alter certain knobs when pulling a source
 // image.
 type PullOptions struct {
-	// Require HTTPS and verify certificates when accessing the registry.
-	TLSVerify bool
+	// Skip TLS verification when accessing the registry.
+	SkipTLSVerify types.OptionalBool
 	// [username[:password] to use when connecting to the registry.
 	Credentials string
 	// Quiet the progress bars when pushing.
@@ -42,7 +42,7 @@ func Pull(ctx context.Context, imageInput string, sourcePath string, options Pul
 	}
 
 	sysCtx := &types.SystemContext{
-		DockerInsecureSkipTLSVerify: types.NewOptionalBool(!options.TLSVerify),
+		DockerInsecureSkipTLSVerify: options.SkipTLSVerify,
 	}
 	if options.Credentials != "" {
 		authConf, err := parse.AuthConfig(options.Credentials)


### PR DESCRIPTION
Ensure we verify the TLS connection when pulling the OCI image.

Bugs: bsc#1245320
Fixes: CVE-2025-6032
