### PR TITLE
vendor/buildah: Don't set ambient capabilities

### DIFF
--- a/vendor/github.com/containers/buildah/chroot/run_linux.go
+++ b/vendor/github.com/containers/buildah/chroot/run_linux.go
@@ -181,7 +181,7 @@ func setCapabilities(spec *specs.Spec, keepCaps ...string) error {
 		capability.EFFECTIVE:   spec.Process.Capabilities.Effective,
 		capability.INHERITABLE: []string{},
 		capability.PERMITTED:   spec.Process.Capabilities.Permitted,
-		capability.AMBIENT:     spec.Process.Capabilities.Ambient,
+		capability.AMBIENT:     {},
 	}
 	knownCaps := capability.List()
 	noCap := capability.Cap(-1)

--- a/vendor/github.com/containers/buildah/run_linux.go
+++ b/vendor/github.com/containers/buildah/run_linux.go
@@ -1033,9 +1033,6 @@ func setupCapAdd(g *generate.Generator, caps ...string) error {
 		if err := g.AddProcessCapabilityPermitted(cap); err != nil {
 			return fmt.Errorf("adding %q to the permitted capability set: %w", cap, err)
 		}
-		if err := g.AddProcessCapabilityAmbient(cap); err != nil {
-			return fmt.Errorf("adding %q to the ambient capability set: %w", cap, err)
-		}
 	}
 	return nil
 }
@@ -1050,9 +1047,6 @@ func setupCapDrop(g *generate.Generator, caps ...string) error {
 		}
 		if err := g.DropProcessCapabilityPermitted(cap); err != nil {
 			return fmt.Errorf("removing %q from the permitted capability set: %w", cap, err)
-		}
-		if err := g.DropProcessCapabilityAmbient(cap); err != nil {
-			return fmt.Errorf("removing %q from the ambient capability set: %w", cap, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
Ambient capabilities can't be raised without inheritable ones, and since we don't raise inheritable, we should not raise ambient either.

This went unnoticed because of a bug in syndtr/gocapability which is only fixed in its fork (see the next commit).

Amends commit e7e55c988.

Bugs: bsc#1252543